### PR TITLE
merging the changes to move to json only ingest config

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ pipeline, with the following command;
 $ conda activate debingest
 ```
 
+The role of the pipeline is to prepare data for dEB analyis and fitting
+with [JKTEBOP](https://www.astro.keele.ac.uk/jkt/codes/jktebop.html).
+
 ## Command line Use
 The entry point for this pipeline is `ingest.py` with example usage shown 
 below. The first example shows running a target ingest based on the 
@@ -185,9 +188,20 @@ specified (they default to 'sf' and 1 if omitted).
 ```json
   "polies": [
     { "term": "sf", "degree": 1, "time_range": [58410.00, 58420.00] },
-    { "term": "sf", "degree": 1, "time_range": [58424.00, 58437.00] },
+    { "term": "sf", "degree": 1, "time_range": [58424.00, 58434.00] },
     { "term": "sf", "degree": 1, "gap_threshold": 0.5 }
   ]
+```
+
+The resulting poly instructions, to be written to the JTEBOP '.in' file, may
+look similar to those shown below. This shows the result of the two manual
+polies above.  In the absence of these, the auto-poly would generate a similar
+output but the date values would be automatically generated from detecting
+gaps in the data.
+
+```
+poly  sf  58415.00  0.0 0.0 0.0 0.0 0.0 0.0  1 1 0 0 0 0  58410.00 58420.00
+poly  sf  58429.00  0.0 0.0 0.0 0.0 0.0 0.0  1 1 0 0 0 0  58424.00 58434.00
 ```
 
 Poly configs are processed in order, with the supported pattern being zero or 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # debingest
 
+## Branch for the move to JSON only ingest config (remove cmd line ingest)
+
 ## Detached Eclipsing Binary Light-curve ingest pipeline
 
 This code base was developed in VSCode (on Ubuntu 22.04) within and an 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ open a Terminal, navigate to this directory and run the following command;
 $ conda env create -f environment.yml
 ```
 
-You will need to activate this environment, prior to running the ingest
+You will need to activate this environment, whenever you wish to use the ingest
 pipeline, with the following command;
 ```sh
 $ conda activate debingest
@@ -85,19 +85,26 @@ parameters, broadly listed in the order they are used.
 }
 ```
 
+Many of these configuration parameters are optional and may be removed or set
+to `null` if the default behaviour is required.
+
+The time values for `quality_mask`, `trim_mask`, or `polies` date ranges are 
+interpreted as BTJD (if < 40 000), reduced JD (< 2.4e6) or JD (>= 2.4e6) all 
+with the scale matching the corresponding light-curve.
+
 ## Processing and parameter usage
 This section describes the ingest pipelines processes and how the parameters
 shown above are used.
 
 The `target` is a compulsory search identifier suitable for locating your target
-in the MAST portal (object name or TIC Id are known to work). The `sys_name` is
+in the MAST portal (object name or TIC are known to work). The `sys_name` is
 an optional name for use in plots and diagnostics messages, which will default
 to the _target_ value if omitted.
 
 The optional `prefix` and `output_dir` values are used to identify where output 
 files are written and how they're named. The prefix is used as a prefix for all
 files. If omitted, the prefix will be derived from the _sys_name_ and the output
-dir will be 'staging/_prefix_/'.
+dir will be 'staging/`prefix`/'.
 
 **Search and download**
 The `target`, `sectors` and `exptime` are used when when querying MAST for 
@@ -106,8 +113,8 @@ assumed to be equivalent to 'any'. Suitable values for _exptime_ are long,
 short, fast or a numeric value in seconds, with 'short' being appropriate for 
 TESS's 120 s cadence light-curve data.  
 
-The `flux_column` may be set to **sap_flux** or pdcsap_flux to indicate
-the source of the flux data to be used.
+The `flux_column` may be set to **sap_flux** (the default value) or pdcsap_flux 
+to indicate the source of the flux data to be used.
 
 > The ingest pipeline makes extensive use of the Lightkurve library. For more
 > information on the _target_, _sectors_, _exptime_, *flux_column* and 
@@ -122,13 +129,14 @@ against the light-curves' QUALITY flag. The *quality_masks* are time ranges
 (from, to) over which all data will be masked from subsequent processing.
 
 > The *quality_masks* and *trim_masks* both take zero or more two element 
-> arrays, each giving the start and end of a time range (i.e.: the following
-> defines two ranges, from JD 2451005 to 2451007 and 2451020 to 2451022 
-> inclusive `[[51005.0, 51007.0], [51020.0, 51022.0]]`)
+> arrays, each giving the start and end of a time range. For example, the 
+> following defines a pair of ranges from JD 2451005 to 2451007 and 2451020 to 
+> 2451022 (inclusive): `[[51005.0, 51007.0], [51020.0, 51022.0]]`
 
 The optional `bin_time` parameter may be set to a time value (in seconds) to 
 which the light-curve data will be (re)binned. This will be ignored if not set 
-or it is given a value which is <= the _exptime_ of the data as it is. 
+or it is given a value which is less than or equal to the _exptime_ of the data 
+as it is. 
 
 Once each light-curves is downloaded, opened, masked and optionally binned the
 fluxes are detrended and used to derive relative magnitudes.
@@ -151,12 +159,12 @@ of the folded light-curve, overlaid with the model, is plotted to a png file.
 **System parameter estimation**
 The reduced folded light-curve is passed to a Machine-Learning model, trained 
 to characterize folded dEB light-curves, for parameter estimation. This 
-gives us estimates the following fitting parameters for each light-curve:
+gives us estimates of the following fitting parameters for each light-curve:
 - `rA_plus_rB` (sum of the relative radii)
 - `k` (ratio of the relative radii)
 - `bA` (primary impact parameter)
 - `inc` (orbital inclination)
-- `ecosw` and `esinw` (eccentrity and argument of periastron)
+- `ecosw` and `esinw` (combined eccentrity and argument of periastron)
 - `J` (surface brightness ratio)
 - `L3` (amount of third light)
 

--- a/README.md
+++ b/README.md
@@ -1,223 +1,209 @@
 # debingest
 
-## Branch for the move to JSON only ingest config (remove cmd line ingest)
-
 ## Detached Eclipsing Binary Light-curve ingest pipeline
 
-This code base was developed in VSCode (on Ubuntu 22.04) within and an 
-**Anaconda** environment named **debingest**. This environment is configured 
-to support _Python 3.8_ and the libraries on which the code is dependent.
+This code base was developed in VSCode (on Ubuntu 22.04) within the context of
+an [Anaconda 3](https://www.anaconda.com/) environment named **debingest**. 
+This environment is configured to support _Python 3.8_ and the libraries on 
+which the code is dependent.
 
 To set up the **debingest** environment, having first cloned the GitHub repo, 
-open a Terminal, navigate to this directory and run the following;
+open a Terminal, navigate to this directory and run the following command;
 ```sh
 $ conda env create -f environment.yml
 ```
 
-Whenever you run the ingest pipeline, it will require this environment be
-active. You can activate it with the following command;
+You will need to activate this environment, prior to running the ingest
+pipeline, with the following command;
 ```sh
 $ conda activate debingest
 ```
 
 ## Command line Use
-The entry point for this pipeline is `ingest.py`.  This should be run in the
-context of the `debingest` environment, with example usage shown below;
-
-```sh
-$ python3 ingest.py -t 'CW Eri' -s 4 -fl sap_flux -q hard -b 240 -p 2.73 -qm 58420.0 58423.0 -pl -pf 
-```
-where
-- `-t`/`--target`: required MAST identifier for the target system to process
-- `-sys`/`--sys-name`: optional system name for labels (defaults to --target)
-- `-pr`/`--prefix`: optional prefix for output files (defaults to --sys-name)
-- `-o`/`--output-dir`: optional output location (defaults to staging/--prefix)
-- `-s`/`--sector`: an optional sector to find - finds all if omitted
-- `-fl`/`--flux`: the flux data column to use: **sap_flux** or pdcsap_flux
-- `-e`/`--exptime`: optionally filter on exposure time: long, short or fast
-- `-q`/`--quality`: the quality filter set: none, **default**, hard or hardes
-- `-qm`/`--quality-mask`: optional time range to mask from any LCs
-  - must have two values - a start and end time (i.e.: -qm 51000.0 52020.0)
-  - these are applied after download and before detrending & conversion to mags
-- `-b`/`--bin-time`: optionally bin the data to bins of this duration (seconds)
-- `-p`/`--period`: the optional orbital period to use - calculated if omittedes
-- `-pl`/`--plot-lc`: instructs the pipeline to plot each lightcurve to a png
-- `-pf`/`--plot-fold`: instructs the pipeline to plot each folded LC to a png
-- `-tm`/`--trim-mask`: optional time range to trim from the final LCs
-  - must have two values - a start and end time (i.e.: -tm 51005.0 51007.5)
-  - trim masks are applied last thing before writting JKTEBOP in & dat files
-
-The `-sys` or `--sys-name` argument will be set to the same value as the target
-if no value given. It is used in plot labels and titles and for the file prefix
-& output directory (unless overriden with values given for `--prefix` or 
-`--output-dir`).
-
-The `-s` or `--sector` argument may be given multiple times, once for each 
-sector required.  If there are no `-s` arguments then all available sectors
-are found for processing. 
-
-The `-qm`/`--quality-mask` and `-tm`/`--trim-mask` arguments may be specified 
-multiple times if masking of multiple time ranges or sectors is required. You 
-cannot specify which sector a mask applies to but, as their observations will 
-cover different times, only those that overlap a given mask will be affected.
-
-> If you first run `chmod +x ingest.py` (or equivalent) in the terminal 
-> you remove the need to specify python3 whenever you run ingest.py.
-
-## Ingest target JSON file use
-**Alternatively** a target's pipeline parameters can be set up in a json file 
-and passed to ingest.py with the `-f` or `--file` argument, as follows:
+The entry point for this pipeline is `ingest.py` with example usage shown 
+below. The first example shows running a target ingest based on the 
+configuration given in an existing config json file.
 
 ```sh
 $ python3 ingest.py -f examples/cw_eri.json
 ```
-where
-- `-f`/`--file`: is the file to load the pipeline parameters from.
 
-The following is the content of cw_eri.json equivalent to the above command 
-line arguments (with the same default values and behaviour). 
+This second example shows how to generate a new default ingest configuration
+json file. Once generated you will need to edit this file to set up the 
+configuration specific to your target.
+```sh
+$ python3 ingest.py -n examples/new_sys.json
+```
+
+> If you first run `chmod +x ingest.py` (or equivalent) in the terminal 
+> you remove the need to specify python3 whenever you run ingest.py.
+
+## The ingest JSON file
+A target's ingest configuration is held in a json file and passed to ingest.py 
+with the `-f` or `--file` argument. An example is shown below with the 
+parameters, broadly listed in the order they are used.
 
 ```json
 {
-  "target": "CW Eri",
-  "sectors": [
-    4
-  ],
-  "flux_column": "sap_flux",
-  "quality_bitmask": "hard",
-  "quality_masks": [
-    [58420.0, 58423.0]
-  ],
-  "bin_time": 240,
-  "period": 2.73,
-  "plot_lc": true,
-  "plot_fold": true,
-  "polies": [],
-  "trim_masks": [],
-  "fitting_params": {}
+    "target": "CW Eri",
+    "sys_name": "CW Eridani",
+    "prefix": "cw_eri",
+    "output_dir": "drop/cw_eri",
+    "sectors": [
+        4,
+        31
+    ],
+    "flux_column": "sap_flux",
+    "exp_time": "short",
+    "quality_bitmask": "hardest",
+    "quality_masks": [
+        [58420.00, 58423.00]
+    ],
+    "bin_time": null,
+    "period": 2.72837,
+    "plot_lc": true,
+    "plot_fold": true,
+    "polies": [
+        { "term": "sf", "degree": 1, "gap_threshold": 0.5 }
+    ],
+    "trim_masks":[
+    ],
+    "fitting_params": {
+        "qphot": 0.836,
+        "L3": 0.080,
+        "LD_A": "pow2",
+        "LD_B": "pow2",
+        "LD_A1": 0.64,
+        "LD_B1": 0.64,       
+        "LD_A1_fit": 1,
+        "LD_B1_fit": 1,
+        "LD_A2": 0.47,
+        "LD_B2": 0.50,
+        "LD_A2_fit": 0,
+        "LD_B2_fit": 0
+    }
 }
 ```
 
-The use of a target ingest json file will allow more complex config to be 
-expressed and for it to be persisted and stored as an asset.
+## Processing and parameter usage
+This section describes the ingest pipelines processes and how the parameters
+shown above are used.
 
-There is support for overriding parameter file values with the previosly 
-discussed command line arguments. The example below shows the quality bitmask 
-in the cw_eri.json file being overriden with the value hardest.
+The `target` is a compulsory search identifier suitable for locating your target
+in the MAST portal (object name or TIC Id are known to work). The `sys_name` is
+an optional name for use in plots and diagnostics messages, which will default
+to the _target_ value if omitted.
 
-```sh
-$ python3 ingest.py -f examples/cw_eri.json -q hardest
-```
+The optional `prefix` and `output_dir` values are used to identify where output 
+files are written and how they're named. The prefix is used as a prefix for all
+files. If omitted, the prefix will be derived from the _sys_name_ and the output
+dir will be 'staging/_prefix_/'.
 
-The json file adds support for configuration that would be difficult to express
-with command line arguments. The initial use was for configuring poly fitting 
-instructions within the JKTEBOP .in files produced. An example is shown below:
+**Search and download**
+The `target`, `sectors` and `exptime` are used when when querying MAST for 
+available timeseries data assets.  Both are optional and if not given they are 
+assumed to be equivalent to 'any'. Suitable values for _exptime_ are long, 
+short, fast or a numeric value in seconds, with 'short' being appropriate for 
+TESS's 120 s cadence light-curve data.  
+
+The `flux_column` may be set to **sap_flux** or pdcsap_flux to indicate
+the source of the flux data to be used.
+
+> The ingest pipeline makes extensive use of the Lightkurve library. For more
+> information on the _target_, _sectors_, _exptime_, *flux_column* and 
+> *quality_bitmask* values see the Lightkurve search and download documentation 
+> [here](http://docs.lightkurve.org/reference/api/lightkurve.search_lightcurve.html)
+
+**Pre-processing data**
+The optional `quality_bitmask` and `quality_masks` are used to mask out poor 
+quality data from a light-curve prior to processing. The *quality_bitmask* may
+be set to none, **default**, hard, hardest or a numeric bitmask to be applied 
+against the light-curves' QUALITY flag. The *quality_masks* are time ranges 
+(from, to) over which all data will be masked from subsequent processing.
+
+> The *quality_masks* and *trim_masks* both take zero or more two element 
+> arrays, each giving the start and end of a time range (i.e.: the following
+> defines two ranges, from JD 2451005 to 2451007 and 2451020 to 2451022 
+> inclusive `[[51005.0, 51007.0], [51020.0, 51022.0]]`)
+
+The optional `bin_time` parameter may be set to a time value (in seconds) to 
+which the light-curve data will be (re)binned. This will be ignored if not set 
+or it is given a value which is <= the _exptime_ of the data as it is. 
+
+Once each light-curves is downloaded, opened, masked and optionally binned the
+fluxes are detrended and used to derive relative magnitudes.
+
+**Finding an orbital ephemeris**
+We now have the light-curve data in a useable state for processing. First the 
+*primary_epoch* is located by selecting the 'most prominent' eclipse in the 
+light-curve. With the `period` (in days), this defines the dEB's ephemeris. The
+_period_ will be estimated using a periodogram of the light-curve if not given.  
+
+The `plot_lc` flag controls whether the light-curve, with *primary_epoch*
+highlighted, is plotted to a png file.
+
+**Phase folding the light-curve**
+The ephemeris is used to phase fold the light-curve data, and a 1024 point
+single phase reduced light-curve is derived for subsequent inspection for 
+system parameter estimation. The `plot_fold` flag controls whether a plot
+of the folded light-curve, overlaid with the model, is plotted to a png file.
+
+**System parameter estimation**
+The reduced folded light-curve is passed to a Machine-Learning model, trained 
+to characterize folded dEB light-curves, for parameter estimation. This 
+gives us estimates the following fitting parameters for each light-curve:
+- `rA_plus_rB` (sum of the relative radii)
+- `k` (ratio of the relative radii)
+- `bA` (primary impact parameter)
+- `inc` (orbital inclination)
+- `ecosw` and `esinw` (eccentrity and argument of periastron)
+- `J` (surface brightness ratio)
+- `L3` (amount of third light)
+
+**Generating JKTEBOP poly instructions**
+During fitting JKTEBOP may alter the light-curve data by fitting polynomials
+to chosen terms, given as `poly` instructions. Generally we instruct it to fit
+low order polynomials to the `sf` (scale factor) term to normalize the data. 
+Each _poly_ instruction applies over a time range and as a rule of thumb each 
+should be a contiguous region of light-curve.
+
+The `polies` config parameter defines what, if any, poly instructions are 
+generated. There are two types: `time_range` (manual poly) configs apply over 
+a user defined time range and `gap_threshold` configs (auto poly) give a gap 
+size (in days) which acts as a boundary between one or more automatically 
+generated time ranges. In both cases a `term` and polynomial `degree` may be 
+specified (they default to 'sf' and 1 if omitted).
 
 ```json
-{
-
   "polies": [
     { "term": "sf", "degree": 1, "time_range": [58410.00, 58420.00] },
     { "term": "sf", "degree": 1, "time_range": [58424.00, 58437.00] },
     { "term": "sf", "degree": 1, "gap_threshold": 0.5 }
   ]
-
-}
 ```
 
-There are now two types of poly config:
-- a _manual poly_ will have a `time_range` parameter
-  - the range over which the poly is applied is specified in the `time_range`
-  - will only be applied to a light-curve where the time ranges overlap
-  - will generate a single poly instruction
-- an _auto-poly_ will have a `gap_threshold` parameter 
-  - can apply to any light-curve
-  - ranges are derived by splitting a light-curve on time gaps > threshold
-  - will generate one or more poly instructions
-- the `term` and `degree` parameter are common to both
+Poly configs are processed in order, with the supported pattern being zero or 
+more _manual polies_ followed by an optional _auto-poly_ (as shown above). For 
+each of the target's light-curves, the manual polies will generate an 
+instruction if there is an overlap with the light-curve on the time axis. The 
+_auto-poly_ will be used only where no _manual polies_ were applied. The two
+types of poly config are mutually exclusive, triggering of one type for a given
+light-curve will cause those of the other type to be subsequently ignored. 
 
-Polies are processed in order, with the supported config being zero or more 
-_manual polies_ listed before a final, optional _auto-poly_ (as 
-shown). For each of the target's light-curves, the manual polies will be tested
-and applied where they overlap with the light-curve on the time axis. The 
-_auto-poly_ will be triggered where no _manual polies_ were applied. This set 
-up allows for selective overriding of a default _auto-poly_ with _manual polies_
-applied to those light-curves where the "gap_threshold" of the default 
-_auto-poly_ is problematic. The different types of poly are exclusive per 
-light-curve, once one has been triggered subsequent polies of a different 
-type will be ignored.
+**Trimming light-curves**
+The optional `trim_masks` config parameter controls what data, if any, is now
+trimmed from the light-curve. Unlike *quality_masks* which are used to mask out 
+poor quality data prior to processing, the *trim_masks* are applied towards
+the end of the pipeline to reduce the data passed on to JKTEBOP for fitting.
+If `plot_lc` is set the trimmed light-curve will be plotted to a png file.
 
-> The time values for clip or poly date ranges will be interpreted as 
-> BTJD (<40,000), reduced JD (<2.4e6) or JD (>= 2.4e6).
-
-The json file also allows you to explicitly set the fitting parameters in the
-JKTEBOP .in files written. You do this by populating a "fitting_params" 
-dictionary in the json file with keys matching the template tokens to be set. 
-The example below sets the photometric mass ratio, 3rd light and limb darkening 
-values with any other token/parameters retaining the values estimated during 
-ingest:
-
-```json
-{
-
-  "fitting_params": {
-    "qphot": 0.836,
-    "L3": 0.080,
-    "LD_A": "pow2",
-    "LD_B": "pow2",
-    "LD_A2": 0.4676,
-    "LD_B2": 0.4967,
-    "LD_A2_fit": 0,
-    "LD_B2_fit": 0
-  },
-
-}
-```
-
-The ./examples/cw_eri.json file is a good example of the range of configuration
-possible using a json file.  Also see the ./library/task3.in.template file to
-see what tokens are set during ingest.
-
-## Generating a new ingest target JSON file
-A new target JSON file can be generated with the `-n` or `--new-file` argument.
-
-```sh
-$ python3 ingest.py -n work/new_sys.json
-```
-where
-- `-n`/`--new-file`: is the file to (over) write out
-
-The new file will be written out with useful default values for most settings.
-Alternatively, you can directly specify many of the values written when the file
-is created by using the command line arguments documented above. The main 
-exception is the target (`-t`) value as the target, file (`-f`) and new-file 
-(`-n`) switches are mutually exclusive. The target value used will be taken from
-the sys-name (if given) or the file name (if not). It is anticipated that you 
-will need to edit the new ingest file before using it for ingest processing.
-
-## Processing
-The pipeline will carry out the following tasks for the specified system:
-- the MAST portal is queried on the target/sectors for TESS/SPOC light-curves
-- any located fits files are downloaded
-- for each fits/sector:
-  - the fits file is read and filtered based on the `--quality` argument
-  - the data is filtered removing rows where the `--flux` column is NaN or <0.0
-  - the `--quality-mask` ranges are applied - any data within these are excluded
-  - if `--bin-time` given, the LC is binned to bins of this duration (seconds)
-  - magnitudes are calculated from the `--flux` and corresponding error columns
-    - a low order polynomial is subtracted to detrend the data
-    - this also y-shifts the data so that the magnitudes are relative to zero
-  - the primary epoch (most prominent eclipse) is found
-  - if no `--period` specified, an estimate period will be found from eclipses
-  - if `--plot-lc` the light-curve & primary epoch is plotted to a png
-  - the magnitude data is phase-folded on the primary eclipse/period
-    - a 1024 point interpolated phase-folded light-curve is derived from this
-    - this is passed to a Machine-Learning model for system parameter estimation
-    - if `--plot-fold` both folded light-curves are plotted to a png
-  - any configured `polies` instructions are generated 
-  - the `--trim-mask` ranges are applied to exclude excess data from the LC
-    - if `--plot-lc` a second "_trimmed" light-curve is plotted to a png
-  - the filtered & masked LC magnitude data is written to a JKTEBOP dat file
-  - the estimated system parameters are used to write a JKTEBOP _task 3_ in file
-    - any overrides from the fitting_params are applied
-    - any polies generated above are appended
+**Generation of JKTEBOP fitting files**
+Finally the processed and reduced light-curve time and magnitude data is 
+written to a JKTEBOP compatible '.dat' file. The parameters for fitting these 
+data are built up from a set of default values and ephemeris, overlaid with the 
+estimated fitting parameters from the ML model and again with any user 
+specified overrides given in the `fitting_params` config. These, along with the
+poly instructions previously generated, are written to a '.in' file which is
+the input instruction and parameters for JKTEBOP to fit the light-curve (the 
+template for this file is found in library/task3.in.template). The default 
+fitting params can be seen at the foot of ingest.py.

--- a/ingest.py
+++ b/ingest.py
@@ -53,7 +53,7 @@ if results:
 
 # This will load the acquired data directly from the cache so we're not 
 # dependent on search/download above. Useful for testing/dev or if MAST down.
-#fits_files = sorted(staging_dir.rglob("tess*_lc.fits"))
+#fits_files = sorted(output_dir.rglob("tess*_lc.fits"))
 #lcs = LightCurveCollection([
 #    lk.read(f"{f}", 
 #            flux_column=config.flux_column, 

--- a/ingest.py
+++ b/ingest.py
@@ -2,9 +2,7 @@
 from pathlib import Path
 import os
 import re
-import argparse
 import textwrap
-import json
 import numpy as np
 import astropy.units as u
 import lightkurve as lk
@@ -18,35 +16,25 @@ from library import lightcurves, plot, jktebop, utility
 # ---------------------------------------------------------------------
 # Handle setting up and interpreting the ingest target configuration
 # ---------------------------------------------------------------------
-ap = utility.set_up_argument_parser()
-args = ap.parse_args()
-if args.new_file is not None:
-    new_file = Path(args.new_file)
-    utility.save_new_ingest_json(new_file, args)
+args = utility.set_up_argument_parser().parse_args()
+if args.new_file:
+    utility.write_ingest_config(
+        args.new_file,
+        utility.new_ingest_config("New Sys", **{
+            "polies": { "term": "sf", "degree": 1, "gap_threshold": 0.5 },
+            "fitting_params": { "dummy_token": "dummy value" }
+        }))
     quit()
-elif args.file:
-    print(f"Configuring pipeline from {args.file} & any command line overrides")
-    # Read the JSON file and use it as the basis of our target config but with
-    # overrides from the command line to apply missing default values or 
-    # otherwise override where non-default values have been given.
-    with open(args.file, "r") as f:
-        file_args = json.load(f)
-        overrides = {k: v for k, v in vars(args).items() 
-                     if k not in file_args or ap.get_default(k) != v}
-        args = argparse.Namespace(**{**file_args, **overrides})
 else:
-    print(f"Configuring pipeline based on command line arguments")
+    config = utility.read_ingest_config(args.file)
 
-utility.echo_ingest_parameters(args)
 detrend_clip = 0.5
 ml_phase_bins = 1024
-sys_name = args.sys_name if args.sys_name else args.target
+sys_name = config.sys_name or config.target
 
 # Set up output locations and file prefixing (& make sure chars are safe subset)
-prefix = re.sub(r'[^\w\d-]', 
-                '_', 
-                args.prefix if args.prefix else sys_name.lower())
-output_dir = args.output_dir if args.output_dir else Path("./staging") / prefix
+prefix = re.sub(r'[^\w\d-]', '_', config.prefix or sys_name.lower())
+output_dir = Path(config.output_dir or f"./staging/{prefix}")
 output_dir.mkdir(parents=True, exist_ok=True)
 print(f"\nWill write files prefixed '{prefix}' to directory {output_dir}")
 
@@ -55,25 +43,25 @@ print(f"\nWill write files prefixed '{prefix}' to directory {output_dir}")
 # Use MAST to DL any timeseries/light-curves for the system/sector(s)
 # ---------------------------------------------------------------------
 lcs = LightCurveCollection([])
-results = lk.search_lightcurve(target=args.target, sector=args.sectors,
-                               mission=args.mission, author=args.author,
-                               exptime=args.exptime)
+results = lk.search_lightcurve(target=config.target, sector=config.sectors,
+                               mission="TESS", author="SPOC",
+                               exptime=config.exptime)
 if results:
     lcs = results.download_all(download_dir=f"{output_dir}", cache=True, 
-                               flux_column=args.flux_column, 
-                               quality_bitmask=args.quality_bitmask)
+                               flux_column=config.flux_column, 
+                               quality_bitmask=config.quality_bitmask)
 
 # This will load the acquired data directly from the cache so we're not 
 # dependent on search/download above. Useful for testing/dev or if MAST down.
 #fits_files = sorted(staging_dir.rglob("tess*_lc.fits"))
 #lcs = LightCurveCollection([
 #    lk.read(f"{f}", 
-#            flux_column=args.flux_column, 
-#            quality_bitmask=args.quality_bitmask) 
+#            flux_column=config.flux_column, 
+#            quality_bitmask=config.quality_bitmask) 
 #    for f in fits_files
 #])
 
-print(f"\nFound {len(lcs)} light-curves for {sys_name} sectors {lcs.sector}.")
+print(f"\nFound {len(lcs)} light-curve(s) for {sys_name} sectors {lcs.sector}.")
 if len(lcs):
     # TODO: Arrange a proper location from which to pick up the model.
     # Suppress annoying TF info messages
@@ -85,13 +73,12 @@ if len(lcs):
 # Process each of the system's light-curves in turn
 # ---------------------------------------------------------------------
 for lc in lcs:  
-    sector = f"{lc.meta['SECTOR']:0>4}"
-    tic = f"{lc.meta['OBJECT']}"
+    sector = lc.meta['SECTOR']
+    file_stem = f"{prefix}_s{sector:0>4}"
     int_time = (lc.meta["INT_TIME"] + lc.meta["READTIME"]) * u.min
-    file_stem = f"{prefix}_s{sector}"
 
-    narrative = f"Processing {len(lc)} row(s) of {args.flux_column} data "\
-        f"(meeting the quality bitmask of {args.quality_bitmask}) "\
+    narrative = f"Processing {len(lc)} row(s) of {config.flux_column} data "\
+        f"(meeting the quality bitmask of {config.quality_bitmask}) "\
         f"for {sys_name} ({lc.meta['OBJECT']}) sector {sector} "\
         f"(camera {lc.meta['CAMERA']}/CCD {lc.meta['CCD']}). This covers the "\
         f"period of {lc.meta['DATE-OBS']} to {lc.meta['DATE-END']} "\
@@ -110,9 +97,9 @@ for lc in lcs:
     filter_mask |= lc.flux < 0
     print(f"NaN/negative flux masks affect {sum(filter_mask.unmasked)} row(s).")
 
-    if args.quality_masks and len(args.quality_masks):
+    if config.quality_masks and len(config.quality_masks):
         print(f"Applying time range quality masks")
-        for qm in args.quality_masks:
+        for qm in config.quality_masks:
             filter_mask |= lightcurves.mask_from_time_range(lc, qm)
 
     lc = lc[~filter_mask]
@@ -123,8 +110,8 @@ for lc in lcs:
     # ---------------------------------------------------------------------
     # Optional binning of the light-curve
     # ---------------------------------------------------------------------
-    if args.bin_time and args.bin_time > 0:
-        bin_time = args.bin_time * u.s
+    if config.bin_time and config.bin_time > 0:
+        bin_time = config.bin_time * u.s
         if int_time.to(u.s) >= bin_time:
             print(f"Light-curve already in bins >= {bin_time}")
         else:
@@ -151,20 +138,20 @@ for lc in lcs:
     # ---------------------------------------------------------------------
     (primary_epoch, primary_epoch_ix) = lightcurves.find_primary_epoch(lc)
     print(f"The primary epoch for sector {sector} is at JD {primary_epoch.jd}")
-    if args.period is None:
+    if config.period:
+        period = config.period * u.d
+        print(f"An orbital period of {period} was specified by the user.")
+    else:
         period = lightcurves.find_period(lc, primary_epoch)
         print(f"No period specified. Found {period} based on eclipse timings.")
-    else:
-        period = args.period * u.d
-        print(f"An orbital period of {period} was specified by the user.")
 
 
     # ---------------------------------------------------------------------
     # Optionally plot the light-curve incl primary eclipse for diagnostics
     # ---------------------------------------------------------------------
-    if args.plot_lc:
+    if config.plot_lc:
         ax = plot.plot_light_curve_on_axes(
-            lc, title=f"{sys_name} sector {sector} light-curve")
+            lc, title=f"Light-curve of {sys_name} sector {sector}")
         primary_mag = lc["delta_mag"][primary_epoch_ix]
         ax.scatter([primary_epoch.value], [primary_mag.value], zorder=-10,
                    marker="x", s=64., lw=.5, c="k", label="primary eclipse")
@@ -182,9 +169,9 @@ for lc in lcs:
     # ---------------------------------------------------------------------
     # Optionally plot the folded LC overlaid with the interpolated one for diags
     # ---------------------------------------------------------------------
-    if args.plot_fold:
-        ax = plot.plot_folded_light_curve_on_axes(fold_lc, column = "delta_mag",
-                    title = f"Folded light-curve of {sys_name} sector {sector}")
+    if config.plot_fold:
+        ax = plot.plot_folded_light_curve_on_axes(
+            fold_lc, title=f"Folded light-curve of {sys_name} sector {sector}")
         ax.scatter(phases, mags, c="k", marker="+", 
                    s=8, alpha=.5, linewidth=.5, zorder=10)
         plt.savefig(output_dir / (file_stem + "_folded.png"), dpi=300)
@@ -209,30 +196,30 @@ for lc in lcs:
     # ---------------------------------------------------------------------
     # Build polies before trimming so they're not affected by gaps from trimming
     # ---------------------------------------------------------------------    
-    poly_instructions = jktebop.build_polies_for_lc(lc, args.polies)
+    poly_instructions = jktebop.build_polies_for_lc(lc, config.polies)
 
 
     # ---------------------------------------------------------------------
     # Apply any user requests to trim the light-curves (for data reduction)
     # ---------------------------------------------------------------------
-    if args.trim_masks is not None and len(args.trim_masks) > 0:
+    if config.trim_masks and len(config.trim_masks) > 0:
         print(f"Applying requested trim masks to final light-curve")
         trim_mask = [False] * len(lc)
-        for tm in args.trim_masks:
+        for tm in config.trim_masks:
             trim_mask |= lightcurves.mask_from_time_range(lc, tm)
         lc = lc[~trim_mask]
         print(f"Trimming masks {sum(trim_mask)} row(s) leaving {len(lc)}.")
 
-        if args.plot_lc:
+        if config.plot_lc:
             ax = plot.plot_light_curve_on_axes(
-                    lc, title=f"Trimmed {sys_name} sector {sector} light-curve")
+                lc, title=f"Trimmed light-curve of {sys_name} sector {sector}")
             plt.savefig(output_dir / (file_stem + "_trimmed.png"), dpi=300)
 
 
     # ---------------------------------------------------------------------
     # Generate JKTEBOP .dat and .in file for task3.
     # ---------------------------------------------------------------------
-    overrides = args.fitting_params if args.fitting_params else {}
+    overrides = config.fitting_params or {}
     params = {
         "rA_plus_rB": rA_plus_rB,
         "k": k,

--- a/library/utility.py
+++ b/library/utility.py
@@ -128,11 +128,11 @@ def echo_ingest_config(config: Union[Namespace, SimpleNamespace, dict],
     return
 
 
-def calculate_inclination(bA: np.double,
-                          rA_plus_rB: np.double,
-                          k: np.double,
-                          ecosw: np.double,
-                          esinw: np.double) -> np.double:
+def calculate_inc(bA: np.double,
+                  rA_plus_rB: np.double,
+                  k: np.double,
+                  ecosw: np.double,
+                  esinw: np.double) -> np.double:
     """
     Calculate the orbital inclination from the impact parameter.
     In training the mae of bA is usually lower, so we'll use that.

--- a/library/utility.py
+++ b/library/utility.py
@@ -1,8 +1,10 @@
 """
 General utility functions not covered elsewhere.
 """
+from typing import Union
 from pathlib import Path
 from argparse import Namespace, ArgumentParser
+from types import SimpleNamespace
 import json
 import numpy as np
 
@@ -25,134 +27,104 @@ relative magnitudes being written to a text dat file and the primary \
 epoch, period and estimated parameters used to create the in file which \
 contains the JKTEBOP processing parameters and instructions.")
 
-    # Must have 1 of these 3. User must specify the target (& all other args) 
-    # at the command line or specify a json file so the args are read from file
-    # (cmd line args still read as an override of file [specific code for this])
     group = ap.add_mutually_exclusive_group(required=True)
-    group.add_argument("-t", "--target", type=str, dest="target",
-                    help="search identifier for the target system to ingest")
     group.add_argument("-f", "--file", type=Path, dest="file",
                     help="JSON file holding a target's ingest configuration")
     group.add_argument("-n", "--new-file", type=str, dest="new_file",
                     help="name of the new JSON configuration file to generate")
 
-    # These are not part of the group above
-    ap.add_argument("-sys", "--sys-name", type=str, 
-                    dest="sys_name", default=None,
-                    help="the system name if different to target")
-    ap.add_argument("-pr", "--prefix", type=str, dest="prefix", 
-                    help="prefix for output files (defaults to sys-name)")
-    ap.add_argument("-o", "--output-dir", type=Path, dest="output_dir", 
-                    help="directory to write to (defaults to staging/sys-name)")
-    
-    ap.add_argument("-s", "--sector", type=int, 
-                    dest="sectors", action="append", metavar="SECTOR",
-                    help="specific sector to find (multiple -s args supported)")
-    #ap.add_argument("-m", "--mission", type=str, dest="mission", default="TESS",
-    #                help="the source mission: currently only supports TESS")
-    #ap.add_argument("-a", "--author", type=str, dest="author", default="SPOC",
-    #                help="the data's author: currently only supports SPOC")
-    ap.add_argument("-fl", "--flux", type=str, 
-                    dest="flux_column", default="sap_flux",
-                    choices=["sap_flux", "pdcsap_flux"],
-                    help="the flux column to use (defaults to sap_flux)")
-    ap.add_argument("-e", "--exptime", type=str, dest="exptime",
-                    help="exposure time/cadence with options of long, short, \
-                        fast or an exact time in seconds (any if omitted)")
-    
-    ap.add_argument("-q", "--quality", type=str, dest="quality_bitmask",
-                    help="quality bitmask to exclude poor quality data: may be \
-                        a numerical bitmask or text {none, default, hard, \
-                        hardest} with a default value of default")
-    ap.add_argument("-qm", "--quality-mask", type=np.double, nargs=2, 
-                    dest="quality_masks", action="append", metavar="TIME",
-                    help="a time range (from, to) to mask out problematic data \
-                        from light-curves prior to processing (multiple -qm \
-                        args supported)")
-    
-    ap.add_argument("-b", "--bin-time", type=np.double, dest="bin_time",
-                    help="optionally bin the light-curve into bins of this \
-                        duration (in seconds)")
-    ap.add_argument("-p", "--period", type=np.double, dest="period",
-                    help="the period of the system (in days) if you wish to \
-                    override the ingest calculated period")
-    
-    ap.add_argument("-pl", "--plot-lc", dest="plot_lc",
-                    action="store_true", required=False,
-                    help="plot of each sector's light-curve to a png file")
-    ap.add_argument("-pf", "--plot-fold", dest="plot_fold",
-                    action="store_true", required=False,
-                    help="plot of each sector folded data to a png file")
-    
-    ap.add_argument("-tm", "--trim-mask", type=np.double, 
-                    nargs=2, dest="trim_masks", action="append", metavar="TIME",
-                    help="a time range (from, to) to trim from the final \
-                        light-curve to reduce the data processing on fitting \
-                        (multiple -tm args supported)")
-
-    ap.set_defaults(target=None, file=None, new_file=None, sys_name=None,
-                    prefix=None, output_dir=None,
-                    sectors=[], mission="TESS", author="SPOC", exptime=None,
-                    flux_column="sap_flux", quality_bitmask="default", 
-                    quality_masks=[], bin_time=None, period=None, 
-                    plot_lc=False, plot_fold=False, 
-                    polies=[], trim_masks=[], fitting_params={})
+    ap.set_defaults(file=None, new_file=None)
     
     # a bit naughty as _optionals is private, but this is a useful clarification
-    ap._optionals.title += " (you must give one of -h, -t, -f or -n)"
+    ap._optionals.title += " (you must give one of -h, -f or -n)"
     return ap
 
 
-def echo_ingest_parameters(args: Namespace):
+def new_ingest_config(target: str, **kwargs) -> Namespace:
     """
-    Will echo any members of the args that don't have a value of None.
+    Will return an ingest config which will be populated with valid
+    default parameters, with overrides from any supplied kwargs.
+
+    :target: the Id of the target system
+    :**kwargs: the values to apply over the defaults
     """
-    print("Ingest parameters being used:")
-    for k, v in vars(args).items():
-        if v:
-            print(f"\t{k} = {v}")
-    return
+    return Namespace(**{
+        "target": target,
+        "sys_name": target,
+        "prefix": None,
+        "output_dir": None,
+        "sectors": [],
+        "flux_column": "sap_flux",
+        "exptime": None,
+        "quality_bitmask": "default",
+        "quality_masks": [],
+        "bin_time": None,
+        "period": None,
+        "plot_lc": False,
+        "plot_fold": False,
+        "polies": [],
+        "trim_masks": [],
+        "fitting_params": {},
+        **kwargs
+    })
 
 
-def save_new_ingest_json(file_name: Path, 
-                         args: Namespace):
+def write_ingest_config(file_name: Path, 
+                        config: Union[Namespace, SimpleNamespace, dict], 
+                        echo: bool = True):
     """
     Will save a new ingest json file to the indicated file_name. The file will
     be populated with default values. Any existing file will be overwritten.
 
-    !file_name! the file to save
-
-    !arg! the args Namespace which will contain any requested values or defaults
-
-    !target! the target name or will default to file_name.stem if omitted
+    :file_name: the file to save
+    :config: the config to write to file
+    :echo: whether to echo the contents of the config to the terminal
     """
-    new_args = vars(args)
-    
-    # Remove stuff that should not be seen in the JSON file
-    for k in ["file", "new_file", "mission", "author"]:
-        if k in new_args:
-            new_args.pop(k)
+    if isinstance(config, Namespace) or isinstance(config, SimpleNamespace):
+        config = vars(config)
 
-    new_args["target"] = new_args.get("sys_name") or file_name.stem
+    if echo:
+        echo_ingest_config(config)
 
-    # Add some dummy values to demonstrate how various settings are written
-    if new_args["quality_masks"] is None or len(new_args["quality_masks"]) == 0:
-        new_args["quality_masks"] = [[45000.0, 45001.0]]
-
-    # Set up a default auto-poly known to work well on TESS light-curves
-    new_args["polies"] = [
-        { "term": "sf", "degree": 1, "gap_threshold": 0.5 }
-    ]
-
-    if new_args["trim_masks"] is None or len(new_args["trim_masks"]) == 0:
-        new_args["trim_masks"] = [[45001.0, 45002.0]]
-
-    new_args["fitting_params"]["dummy_token"] = "value"
-    
-    echo_ingest_parameters(args)
     with open(file_name, "w") as f:
-        json.dump(new_args, f, ensure_ascii=False, indent=2)
-        print(f"New ingest target JSON file saved to '{f.name}'")
+        json.dump(config, f, ensure_ascii=False, indent=2)
+        print(f"Ingest config written to {f.name}")
+    return
+
+
+def read_ingest_config(file_name: Path, 
+                       echo: bool = True) -> Namespace:
+    """
+    Reads the ingest config from the passed file.
+
+    :file_name: the file to read from
+    :echo: whether to echo the contents of the config to the terminal
+    """
+    print(f"Reading ingest config from {file_name}")
+    with open(file_name, "r") as f:
+        file_config = json.load(f)
+
+    # We explicitly request target so we get a KeyError if not present
+    config = new_ingest_config(file_config.pop("target"), **file_config)
+
+    if echo:
+        echo_ingest_config(config)
+    return config
+
+
+def echo_ingest_config(config: Union[Namespace, SimpleNamespace, dict],
+                       show_nones: bool = False):
+    """
+    Will echo any members of the config except those of value of None
+    (unless :show_nones: is true).
+    """
+    if isinstance(config, Namespace) or isinstance(config, SimpleNamespace):
+        config = vars(config)
+
+    print("The ingest configuration is:")
+    for k, v in config.items():
+        if show_nones or v:
+            print(f"\t{k} = {v}")
     return
 
 


### PR DESCRIPTION
Removed support for most command line args (as they were getting increasingly difficult to maintain) and we now only support configuring a target ingest from a json file.  Allowed for much cleaner code so much simplification. Includes updated documentation.

Also includes a change which rounds estimated fitting params.